### PR TITLE
[fix] Positioning of bg image in input fields

### DIFF
--- a/src/mixins/_mixins.scss
+++ b/src/mixins/_mixins.scss
@@ -34,8 +34,7 @@
 
 	background: {
 		color: $bg-color;
-		position-x: right 5px;
-		position-y: bottom 50%;
+		position: calc(100% - 5px) 50%;
 		repeat: no-repeat;
 		image: $image;
 		size: $size;


### PR DESCRIPTION
background-position-x/-y is currently only supported in Firefox and Safari. This two-value-variation using background-position works the same.

References https://github.com/gebruederheitz/schaeffer-poeschel-de-2019/issues/352